### PR TITLE
Fix typo in README, provide link for a USB-TTL adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To build the FlashFloppy firmware:
 ## Initial Installation
 
 The first installation of this firmware onto Gotek requires a USB-TTL
-serial dapter, with the Gotek jumpered into system-bootloader
+serial adapter (such as [the CAB-12977 from SparkFun](https://www.sparkfun.com/products/12977)), with the Gotek jumpered into system-bootloader
 mode. This process is described on the Cortex firmware webpage
 [here](https://cortexamigafloppydrive.wordpress.com).
 


### PR DESCRIPTION
I noticed a typo in the README ("dapter" instead of "adapter") and I thought it'd be handy to provide a link to a USB-TTL adapter as well, mainly so the commit isn't just one letter long. 

I picked SparkFun as they were one of the first hits in google, and I've used them before so I know they're a reputable company with good service. (It's not an affiliate link or anything like that)

(Thanks for the great project! I'll definitely be trying this out when I get a chance.)