### PR TITLE
Add support for PC98 host, with raw and FDI formats.

### DIFF
--- a/inc/config.h
+++ b/inc/config.h
@@ -71,6 +71,7 @@ struct __packed ff_cfg {
 #define HOST_ti99        5
 #define HOST_memotech    6
 #define HOST_uknc        7
+#define HOST_pc98        8
     uint8_t host;
     /* Bitfields within display_type field. */
 #define DISPLAY_lcd    (1<<0)

--- a/inc/floppy.h
+++ b/inc/floppy.h
@@ -40,6 +40,7 @@ struct hfe_image {
 struct img_image {
     uint32_t trk_off, base_off;
     uint16_t trk_sec;
+    uint16_t rpm;
     int32_t decode_pos;
     uint8_t layout; /* LAYOUT_* */
     bool_t has_iam;

--- a/src/image/image.c
+++ b/src/image/image.c
@@ -17,6 +17,7 @@ extern const struct image_handler dsk_image_handler;
 extern const struct image_handler da_image_handler;
 extern const struct image_handler adfs_image_handler;
 extern const struct image_handler mgt_image_handler;
+extern const struct image_handler pc98fdi_image_handler;
 extern const struct image_handler trd_image_handler;
 extern const struct image_handler opd_image_handler;
 extern const struct image_handler ssd_image_handler;
@@ -44,6 +45,7 @@ bool_t image_valid(FILINFO *fp)
                || !strcmp(ext, "adl")
                || !strcmp(ext, "adm")
                || !strcmp(ext, "mgt")
+               || !strcmp(ext, "fdi")
                || !strcmp(ext, "trd")
                || !strcmp(ext, "opd")
                || !strcmp(ext, "ssd")
@@ -112,6 +114,7 @@ void image_open(struct image *im, const struct slot *slot)
             : !strcmp(ext, "adl") ? &adfs_image_handler
             : !strcmp(ext, "adm") ? &adfs_image_handler
             : !strcmp(ext, "mgt") ? &mgt_image_handler
+            : !strcmp(ext, "fdi") ? &pc98fdi_image_handler
             : !strcmp(ext, "trd") ? &trd_image_handler
             : !strcmp(ext, "opd") ? &opd_image_handler
             : !strcmp(ext, "ssd") ? &ssd_image_handler

--- a/src/main.c
+++ b/src/main.c
@@ -174,6 +174,7 @@ static void display_write_slot(bool_t nav_mode)
         : slot_type("adl") ? "ADL"
         : slot_type("adm") ? "ADM"
         : slot_type("mgt") ? "MGT"
+        : slot_type("fdi") ? "FDI"
         : slot_type("trd") ? "TRD"
         : slot_type("opd") ? "OPD"
         : slot_type("ssd") ? "SSD"
@@ -486,6 +487,7 @@ static void read_ff_cfg(void)
                 : !strcmp(opts.arg, "ensoniq") ? HOST_ensoniq
                 : !strcmp(opts.arg, "gem") ? HOST_gem
                 : !strcmp(opts.arg, "memotech") ? HOST_memotech
+                : !strcmp(opts.arg, "pc98") ? HOST_pc98
                 : !strcmp(opts.arg, "ti99") ? HOST_ti99
                 : !strcmp(opts.arg, "uknc") ? HOST_uknc
                 : HOST_unspecified;


### PR DESCRIPTION
For the img format, host must be set to pc98 in order to get the
most common 360 rpm formats.

For the FDI format (from the Anex86 emulator, not to be confused
with the Amiga FDI format), parameters are loaded from the image
header.

I have not tested anything other than 1.2MB as I don't have any
disks or images of other types.