### PR TITLE
PC98 HDM image handler WIP

### DIFF
--- a/src/image/image.c
+++ b/src/image/image.c
@@ -1,10 +1,10 @@
 /*
  * image.c
- * 
+ *
  * Interface for accessing image files.
- * 
+ *
  * Written & released by Keir Fraser <keir.xen@gmail.com>
- * 
+ *
  * This is free and unencumbered software released into the public domain.
  * See the file COPYING for more details, or visit <http://unlicense.org>.
  */
@@ -20,6 +20,7 @@ extern const struct image_handler adfs_image_handler;
 extern const struct image_handler mbd_image_handler;
 extern const struct image_handler mgt_image_handler;
 extern const struct image_handler pc98fdi_image_handler;
+extern const struct image_handler pc98hdm_image_handler;
 extern const struct image_handler trd_image_handler;
 extern const struct image_handler opd_image_handler;
 extern const struct image_handler ssd_image_handler;
@@ -34,6 +35,7 @@ const struct image_type image_type[] = {
     { "adf", &adf_image_handler },
     { "d81", &d81_image_handler },
     { "dsk", &dsk_image_handler },
+    { "hdm", &pc98hdm_image_handler },
     { "hfe", &hfe_image_handler },
     { "img", &img_image_handler },
     { "ima", &img_image_handler },
@@ -103,7 +105,7 @@ static bool_t try_handler(struct image *im, const struct slot *slot,
     if (handler->write_track != NULL)
         mode |= FA_WRITE;
     fatfs_from_slot(&im->fp, slot, mode);
-    
+
     return handler->open(im);
 }
 

--- a/src/image/img.c
+++ b/src/image/img.c
@@ -1,10 +1,10 @@
 /*
  * img.c
- * 
+ *
  * Sector image files for IBM/ISO track formats.
- * 
+ *
  * Written & released by Keir Fraser <keir.xen@gmail.com>
- * 
+ *
  * This is free and unencumbered software released into the public domain.
  * See the file COPYING for more details, or visit <http://unlicense.org>.
  */
@@ -344,6 +344,22 @@ static bool_t pc98fdi_open(struct image *im)
     return mfm_open(im);
 }
 
+static bool_t pc98hdm_open(struct image *im) {
+    im->img.rpm = 360;
+    im->img.gap_3 = 116;
+    im->img.sec_no = 3;
+
+    im->nr_cyls = 77;
+    im->nr_sides = 2;
+    im->img.nr_sectors = 8;
+    im->img.interleave = 1;
+    im->img.sec_base[0] = im->img.sec_base[1] = 1;
+    im->img.skew = 0;
+    im->img.has_iam = TRUE;
+    im->img.base_off = 0;
+    return mfm_open(im);
+}
+
 struct bpb {
     uint16_t sig;
     uint16_t bytes_per_sec;
@@ -351,7 +367,7 @@ struct bpb {
     uint16_t num_heads;
     uint16_t tot_sec;
 };
-    
+
 static void bpb_read(struct image *im, struct bpb *bpb)
 {
     uint16_t x;
@@ -836,6 +852,14 @@ const struct image_handler mgt_image_handler = {
 
 const struct image_handler pc98fdi_image_handler = {
     .open = pc98fdi_open,
+    .setup_track = img_setup_track,
+    .read_track = img_read_track,
+    .rdata_flux = bc_rdata_flux,
+    .write_track = img_write_track,
+};
+
+const struct image_handler pc98hdm_image_handler = {
+    .open = pc98hdm_open,
     .setup_track = img_setup_track,
     .read_track = img_read_track,
     .rdata_flux = bc_rdata_flux,

--- a/src/image/img.c
+++ b/src/image/img.c
@@ -345,19 +345,7 @@ static bool_t pc98fdi_open(struct image *im)
 }
 
 static bool_t pc98hdm_open(struct image *im) {
-    im->img.rpm = 360;
-    im->img.gap_3 = 116;
-    im->img.sec_no = 3;
-
-    im->nr_cyls = 77;
-    im->nr_sides = 2;
-    im->img.nr_sectors = 8;
-    im->img.interleave = 1;
-    im->img.sec_base[0] = im->img.sec_base[1] = 1;
-    im->img.skew = 0;
-    im->img.has_iam = TRUE;
-    im->img.base_off = 0;
-    return mfm_open(im);
+    return _img_open(im, pc98_type);
 }
 
 struct bpb {


### PR DESCRIPTION
These are the changes we discussed in #198. Thanks for the tips - it was a huge help to know exactly where to look.

Here's what I did:
 - Made `pc98hdm_open` read hardcoded values (based on my successful FDI header values)
 - Added a handler to `image.c` and wired it up in `img.c` using all of the same values as the FDI ones - except for the `.open` function pointer.

I wasn't able to build it on my local machine to test, because I don't have `srec_cat` installed on my Mac. I will see if I can get the tools installed on a Linux machine later and update my FlashFloppy'd Gotek.

It looks also like my editor (Atom) has decided to do some cleanup of blank lines with excessive whitespace, sorry for the ugly diff.