### PR TITLE
added textsize config-switch

### DIFF
--- a/examples/FF.CFG
+++ b/examples/FF.CFG
@@ -178,6 +178,11 @@ indexed-prefix = "DSKA"
 # Values: auto | lcd-NNx02 | oled-128xNN[-rotate][-narrow[er]]
 display-type = auto
 
+# Double Textheight per textrow (oled - 128x64pixel)
+# Multiple values can be separated by commas, one for each display-rows
+# Values: small | big
+display-textsize = small,big
+
 # OLED Font. Narrow and wide options.
 # Narrower 6x13 font permits:
 #  - More characters per row

--- a/inc/config.h
+++ b/inc/config.h
@@ -100,6 +100,9 @@ struct __packed ff_cfg {
 #define _DISPLAY_lcd_columns 5
 #define DISPLAY_lcd_columns(x) ((x)<<_DISPLAY_lcd_columns)
     uint16_t display_type;
+#define TEXTSIZE_small 0
+#define TEXTSIZE_big   1
+    uint8_t display_textsize;
 #define ROT_none      0
 #define ROT_full      1
 #define ROT_half      3

--- a/scripts/mk_config.py
+++ b/scripts/mk_config.py
@@ -55,6 +55,11 @@ def main(argv):
                 for x in val.split(","):
                     opts += ['TWOBUTTON_' + x.replace("-","_")]
                 val = '|'.join(opts)
+            elif opt == "display-textsize":
+                opts = []
+                for x in val.split(","):
+                    opts += ['TEXTSIZE_' + x]
+                val = '|'.join(opts)
             elif opt == "nav-mode":
                 val = "NAVMODE_" + val
             elif opt == "folder-sort":

--- a/src/main.c
+++ b/src/main.c
@@ -1010,6 +1010,22 @@ static void read_ff_cfg(void)
             break;
         }
 
+        case FFCFG_display_textsize: {
+            char *p, *q;
+            uint8_t i = 0;
+            ff_cfg.display_textsize = (TEXTSIZE_small<<0) | (TEXTSIZE_small<<1);
+            for (p = opts.arg; *p != '\0'; p = q) {
+                for (q = p; *q && *q != ','; q++)
+                    continue;
+                if (*q == ',')
+                    *q++ = '\0';
+                ff_cfg.display_textsize |=
+                    !strcmp(p, "big") ? (TEXTSIZE_big<<i) : (TEXTSIZE_small<<i);
+                ++i;
+            }
+            break;
+        }
+
         case FFCFG_oled_font:
             ff_cfg.oled_font =
                 !strcmp(opts.arg, "6x13") ? FONT_6x13


### PR DESCRIPTION
addresses issue #234: better support of 128x64 OLED
new option "display_textsize" added to FF.CFG
values are "big" / "small" - define of text will be
doubled in height or left as is.