### PR TITLE
added text_rowcontent config-switch

### DIFF
--- a/examples/FF.CFG
+++ b/examples/FF.CFG
@@ -215,6 +215,11 @@ nav-scroll-rate = 80
 # Values: 0 <= N <= 65535
 nav-scroll-pause = 300
 
+# Text row content
+# Multiple values can be separated by commas, one for each display-rows
+# Values: none | name | track
+text-rowcontent = name,track
+
 ##
 ## MISCELLANEOUS
 

--- a/inc/config.h
+++ b/inc/config.h
@@ -100,6 +100,11 @@ struct __packed ff_cfg {
 #define _DISPLAY_lcd_columns 5
 #define DISPLAY_lcd_columns(x) ((x)<<_DISPLAY_lcd_columns)
     uint16_t display_type;
+#define TEXT_none      0
+#define TEXT_name      1
+#define TEXT_track     2
+#define TEXT_spare     3
+    uint8_t text_rowcontent;
 #define ROT_none      0
 #define ROT_full      1
 #define ROT_half      3

--- a/inc/util.h
+++ b/inc/util.h
@@ -152,6 +152,10 @@ extern uint8_t display_mode;
 void speaker_init(void);
 void speaker_pulse(void);
 
+/* Text row contents */
+extern uint8_t diskname_row;
+extern uint8_t trackinfo_row;
+
 /* Display: 3-digit 7-segment display */
 void led_7seg_init(void);
 void led_7seg_write_string(const char *p);

--- a/scripts/mk_config.py
+++ b/scripts/mk_config.py
@@ -55,6 +55,11 @@ def main(argv):
                 for x in val.split(","):
                     opts += ['TWOBUTTON_' + x.replace("-","_")]
                 val = '|'.join(opts)
+            elif opt == "text-rowcontent":
+                opts = []
+                for x in val.split(","):
+                    opts += ['TEXT_' + x]
+                val = '|'.join(opts)
             elif opt == "nav-mode":
                 val = "NAVMODE_" + val
             elif opt == "folder-sort":

--- a/src/display/lcd.c
+++ b/src/display/lcd.c
@@ -67,6 +67,10 @@ static uint8_t buffer[256] __aligned(4);
 /* Text buffer, rendered into I2C data and placed into buffer[]. */
 static char text[2][40];
 
+/* Text content */
+uint8_t diskname_row;
+uint8_t trackinfo_row;
+
 /* Columns and rows of text. */
 uint8_t lcd_columns, lcd_rows;
 
@@ -396,6 +400,8 @@ bool_t lcd_init(void)
             lcd_columns = max_t(uint8_t, lcd_columns, 16);
             lcd_columns = min_t(uint8_t, lcd_columns, 40);
         }
+        diskname_row  = ff_cfg.text_rowcontent & 0x03;
+        trackinfo_row = (ff_cfg.text_rowcontent>>2) & 0x03;
 
         printk("I2C: %s found at 0x%02x\n",
                is_oled_display ? "OLED" : "LCD", a);


### PR DESCRIPTION
addresses issue #236 - selecting text row-content
new option to FF.CFG to select which textrow contains
which output on lcd/oled displays.
values are "name" / "track".
the position of these keywords define the row.

only imagename and trackinfo texts will be affected.