### PR TITLE
Implement handling of hdout switch for Amiga .adf images

### DIFF
--- a/src/floppy.c
+++ b/src/floppy.c
@@ -300,7 +300,7 @@ void floppy_insert(unsigned int unit, struct slot *slot)
     floppy_mount(slot);
     im = image;
 
-    if (im->write_bc_ticks < sysclk_ns(1500))
+    if (im->write_bc_ticks < sysclk_ns(1500) || im->adf.nr_secs == 22)
         drive_change_output(drv, outp_hden, TRUE);
 
     timer_dma_init();


### PR DESCRIPTION
For me, this solves issue #293 
I don't think this will have implications for other image types than adf, but @keirf, perhaps you can say something about it.