### PR TITLE
Added new RAW image format for IBM 3174

### DIFF
--- a/examples/FF.CFG
+++ b/examples/FF.CFG
@@ -26,6 +26,7 @@ interface = jc
 # ensoniq: Ensoniq (ASR, TS, etc)
 # fluke: Fluke 9100
 # gem: General Music (S2, S3)
+# ibm-3174: IBM 3174 Establishment Controller
 # kaypro: Kaypro
 # memotech: Memotech
 # msx: MSX

--- a/inc/config.h
+++ b/inc/config.h
@@ -85,6 +85,7 @@ struct packed ff_cfg {
 #define HOST_kaypro     14
 #define HOST_nascom     15
 #define HOST_casio      16
+#define HOST_ibm_3174   17
     uint8_t host;
     /* Bitfields within display_type field. */
 #define DISPLAY_auto     0

--- a/src/main.c
+++ b/src/main.c
@@ -895,6 +895,7 @@ static void read_ff_cfg(void)
                 : !strcmp(opts.arg, "ensoniq") ? HOST_ensoniq
                 : !strcmp(opts.arg, "fluke") ? HOST_fluke
                 : !strcmp(opts.arg, "gem") ? HOST_gem
+                : !strcmp(opts.arg, "ibm-3174") ? HOST_ibm_3174
                 : !strcmp(opts.arg, "kaypro") ? HOST_kaypro
                 : !strcmp(opts.arg, "memotech") ? HOST_memotech
                 : !strcmp(opts.arg, "msx") ? HOST_msx


### PR DESCRIPTION
I have added a new RAW image format to support IBM 3174 controllers. These controllers use a 5-1/4" drive that can store 2.4MB on each disk. Most of the parameters are the same as a 1.2MB high density disk except that it runs at 180rpm instead of 360rpm. This allows twice the number of sectors to be stored on each track. Some of the disks used with this controller use the standard 1.2 MB high density format. In order for the controller to determine what type of disk has been inserted the first cylinder is always formatted 1.2MB high density (15 sectors of 512 bytes, 360rpm). For a 2.4MB disk it is only cylinders 1-79 that are formatted at extended density (30 sectors of 512 bytes, 180rpm).

Pin 2 of the floppy interface is used to control the drive rotational speed. I ignore that input for this implementation as I can set the disk speed based upon the type of image loaded and which cylinder is being accessed.

Pin 4 seems to be some kind of 'drive ready' output which needs to be asserted when the drive is selected. Unfortunately this pin is not programmable on the Gotek so hardware modifications are required. I have found that for a single drive system you can get away with installing jumper J5 which permanently ties this signal to ground. For a dual drive system a diode needs to be installed between pin 4 and the internal drive select line.

![gotek_3174_mod](https://user-images.githubusercontent.com/5875083/73613226-5d1c7a80-45eb-11ea-95e4-e087ffb72c4c.png)

Jumper S1 should be installed to set the drive ID. The 3174 seems to use the PC convention where the drive is always set it ID 1 and the cable selects the actual ID.

I've tested this with a 3174-21R with two drives and a 3174-91R with a single drive. A friend has also tested this with a 3174-21R and 3174-51R with two drives.