### PR TITLE
Add hard sector support to infrastructure and HFE

### DIFF
--- a/inc/floppy.h
+++ b/inc/floppy.h
@@ -48,6 +48,7 @@ struct hfe_image {
     uint16_t trk_off;
     uint16_t trk_pos, trk_len;
     bool_t is_v3, double_step;
+    uint8_t next_index_pulses_pos;
     uint8_t batch_secs;
     struct {
         uint16_t start;
@@ -151,6 +152,8 @@ struct image_bufs {
     struct image_buf read_data;
 };
 
+#define MAX_CUSTOM_PULSES 33
+
 struct image {
     /* Handler for currently-selected type of disk image. */
     const struct image_handler *disk_handler;
@@ -163,6 +166,11 @@ struct image {
 
     /* Info about image as a whole. */
     uint8_t nr_cyls, nr_sides;
+    uint8_t index_pulses_ver; /* Changed when pulses or length changed. */
+    uint8_t index_pulses_len;
+    /* Alternative index pulse locations, in ticks. When non-empty, disables
+     * regular index pulse. */
+    uint32_t index_pulses[MAX_CUSTOM_PULSES];
 
     /* Data buffers. */
     struct image_bufs bufs;

--- a/src/gotek/floppy.c
+++ b/src/gotek/floppy.c
@@ -271,8 +271,9 @@ static void IRQ_STEP_changed(void)
         rdata_stop();
         if (!ff_cfg.index_suppression) {
             /* Opportunistically insert an INDEX pulse ahead of seek op. */
-            drive_change_output(drv, outp_index, TRUE);
-            index.fake_fired = TRUE;
+            // FIXME: But why? Delete fake_fired completely?
+            //drive_change_output(drv, outp_index, TRUE);
+            //index.fake_fired = TRUE;
         }
     }
     IRQx_set_pending(FLOPPY_SOFTIRQ);

--- a/src/image/hfe.c
+++ b/src/image/hfe.c
@@ -138,7 +138,7 @@ static void hfe_setup_track(
 {
     struct image_buf *rd = &im->bufs.read_data;
     struct image_buf *bc = &im->bufs.read_bc;
-    uint32_t sys_ticks;
+    uint32_t sys_ticks, opcode_adj_bc = 0;
     uint8_t cyl = track >> (im->hfe.double_step ? 2 : 1);
     uint8_t side = track & (im->nr_sides - 1);
     int i;
@@ -149,25 +149,41 @@ static void hfe_setup_track(
 
     sys_ticks = start_pos ? *start_pos : get_write(im, im->wr_cons)->start;
     im->cur_bc = (sys_ticks * 16) / im->ticks_per_cell;
-    if (im->cur_bc >= im->tracklen_bc)
+    if (im->tracklen_ticks > 0
+        && im->tracklen_ticks < im->tracklen_bc * im->ticks_per_cell) {
+
+        /* If there are opcodes (other than random) in the track, seeking will
+         * not be precise as opcodes contribute zero bitcells and thus zero
+         * ticks. The HFE track data will _appear_ misaligned to the previous
+         * until the track is read from the beginning. Misalignment greater
+         * than 3 ms is possible. This is most obvious for OP_index timing but
+         * can also shift writes backward in time.
+         *
+         * Severe misalignment is most likely caused by regular occurrences of
+         * OP_bitrate evenly distributed through the track. Assume opcodes
+         * numerous enough to become noticeable are evenly distributed in the
+         * track.
+         */
+        uint32_t assumed_tracklen_ticks = im->tracklen_bc * im->ticks_per_cell;
+        uint32_t opcode_ticks = assumed_tracklen_ticks - im->tracklen_ticks;
+        uint32_t opcode_bc = opcode_ticks / im->ticks_per_cell;
+        opcode_adj_bc = im->cur_bc * opcode_bc / (im->tracklen_bc - opcode_bc); 
+    }
+    if (im->cur_bc + opcode_adj_bc >= im->tracklen_bc) {
         im->cur_bc = 0;
+        opcode_adj_bc  = 0;
+    }
     im->cur_ticks = im->cur_bc * im->ticks_per_cell;
     im->ticks_since_flux = 0;
+
+    /* Must be careful to exclude opcode_adj_bc from tick calculations. */
+    im->cur_bc += opcode_adj_bc;
 
     sys_ticks = im->cur_ticks / 16;
 
     rd->prod = rd->cons = 0;
     bc->prod = bc->cons = 0;
 
-    /* If there are opcodes (other than random) in the track, seeking will not
-     * be precise as opcodes contribute zero bitcells. The HFE track data will
-     * _appear_ misaligned to the previous until the track is read from the
-     * beginning. So even with perfectly aligned HFE tracks, we'll find this
-     * new track has different pulses than the previous.
-     *
-     * Note that this problem also applies to writes and will shift writes
-     * backward in time.
-     */
     for (i = 0; i < im->index_pulses_len; i++)
         if (im->cur_ticks < im->index_pulses[i])
             break;


### PR DESCRIPTION
Alternative to #401. This drops the VGI support that it used. I have VGI read support with this version in my own repo but removed it because it did not support writes and it seemed there was a preference to go with the general-purpose HFE instead of many custom image formats. It proved to be very helpful during development though.

This is more invasive than #401, although the infrastructure enhancements seem fair. I considered many  The HFE changes were the trickier ones.

There are two FIXMEs in the code commenting out code for `fake_fired`. The code was causing trouble, and it was unclear what the intention was since it was in the `index_suppression == FALSE` case. I assume that will be resolved before merging.

HFE index pulses do not have to come at the beginning of the track, so normal pulses are disabled when custom pulses are being used. Syncing the custom pulses immediately when they are changed is required because HFE tracks don't have to be aligned with each other and because seeking ignores opcodes which causes temporary skew.

The index pulses with this change and `index-suppression=no` are very consistent during reading/seeking. I still have not tested with real hardware, but pulses during writes with all three `write-drain` settings behave as expected and realtime and eot are promising for actual hardware compatibility.

The hard-sectored HFE files that I could find were clearly recordings and not all that pretty. I did test them and they did work, but I also created my own 16 sector files. I'll post the script I used to generate it to #400.

Fixes #393 #400

CC @teiram 