### PR TITLE
Improve gc-sections binary reduction with finer-grained sections

### DIFF
--- a/Rules.mk
+++ b/Rules.mk
@@ -14,7 +14,7 @@ FLAGS += -Wall -Werror -Wno-format -Wdeclaration-after-statement
 FLAGS += -Wstrict-prototypes -Wredundant-decls -Wnested-externs
 FLAGS += -fno-common -fno-exceptions -fno-strict-aliasing
 FLAGS += -mlittle-endian -mthumb -mcpu=cortex-m3 -mfloat-abi=soft
-FLAGS += -Wno-unused-value
+FLAGS += -Wno-unused-value -fdata-sections -ffunction-sections
 
 ifneq ($(debug),y)
 FLAGS += -DNDEBUG


### PR DESCRIPTION
Saves about 1k for a normal build. Allows building bootloader in debug
mode.