### PR TITLE
Align F_lseek definition with declaration

### DIFF
--- a/src/fs.c
+++ b/src/fs.c
@@ -124,7 +124,7 @@ void F_truncate(FIL *fp)
 
 #endif /* !FF_FS_READONLY */
 
-void F_lseek(FIL *fp, LBA_t ofs)
+void F_lseek(FIL *fp, FSIZE_t ofs)
 {
     FRESULT fr;
 #if !FF_FS_READONLY


### PR DESCRIPTION
Doesn't hurt much because the two types have the same size, but was a
bit confusing.