### PR TITLE
Adapt strnlen bound to actual buffer size

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1824,7 +1824,7 @@ indexed_mode:
                  fs->fp.fname[0] != '\0';
                  F_findnext(&fs->dp, &fs->fp)) {
                 const char *p = fs->fp.fname
-                    + strnlen(ff_cfg.indexed_prefix, 256);
+                    + strnlen(ff_cfg.indexed_prefix, 8);
                 unsigned int idx = 0;
                 /* Skip directories. */
                 if (fs->fp.fattrib & AM_DIR)


### PR DESCRIPTION
Full error message from GCC
```
CC main.o
In function 'hxc_cfg_update',
    inlined from 'cfg_update' at main.c:1892:9:
main.c:1827:23: error: 'strnlen' specified bound 256 exceeds source size 8 [-Werror=stringop-overread]
 1827 |                     + strnlen(ff_cfg.indexed_prefix, 256);
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /abuild/projects/Emulator/Gotek/FlashFloppy/inc/decls.h:36,
                 from <command-line>:
main.c: In function 'cfg_update':
/abuild/projects/Emulator/Gotek/FlashFloppy/inc/config.h:140:10: note: source object declared here
  140 |     char indexed_prefix[8];
      |          ^~~~~~~~~~~~~~
cc1: all warnings being treated as errors

```

Signed-off-by: Klaus Kämpf <kkaempf@suse.de>