### PR TITLE
Add in mention of ndens being used on Epson PC-98 clones

### DIFF
--- a/examples/FF.CFG
+++ b/examples/FF.CFG
@@ -48,7 +48,7 @@ host = unspecified
 # rdy: Drive ready (Ready = 0v)
 # nrdy: Logical complement of above
 # dens: Density mode (High Density = 0v)
-# ndens: Logical complement of above
+# ndens: Logical complement of above (used on some Epson PC-98 clones such as the PC-486GR, etc.)
 # chg: Disk changed (Changed = 0v)
 # nchg: Logical complement of above
 # Values: auto, nc, low, high, rdy, nrdy, dens, ndens, chg, nchg


### PR DESCRIPTION
Some PC-98 clones by Epson use an inverted density mode selection on Pin 2, I've confirmed this on a real PC-486GR. Source: 
https://98epjunk.shakunage.net/fdd/ep_density.html https://98epjunk.shakunage.net/fdd/ep_fdd_pc98.html