### PR TITLE
Avoid fake_fired for realtime seek/write

### DIFF
--- a/src/floppy_generic.c
+++ b/src/floppy_generic.c
@@ -365,7 +365,7 @@ static void wdata_stop(void)
     image->wr_prod++;
 
 #if !defined(QUICKDISK)
-    if (!ff_cfg.index_suppression) {
+    if (!ff_cfg.index_suppression && ff_cfg.write_drain != WDRAIN_realtime) {
         /* Opportunistically insert an INDEX pulse ahead of writeback. */
         drive_change_output(drv, outp_index, TRUE);
         index.fake_fired = TRUE;

--- a/src/gotek/floppy.c
+++ b/src/gotek/floppy.c
@@ -325,7 +325,8 @@ static void IRQ_STEP_changed(void)
         drive_change_output(drv, outp_trk0, FALSE);
     if (dma_rd != NULL) {
         rdata_stop();
-        if (!ff_cfg.index_suppression) {
+        if (!ff_cfg.index_suppression
+                && ff_cfg.track_change != TRKCHG_realtime) {
             /* Opportunistically insert an INDEX pulse ahead of seek op. */
             drive_change_output(drv, outp_index, TRUE);
             index.fake_fired = TRUE;


### PR DESCRIPTION
fake_fired inserts an index pulse to avoid host-side timeouts. However, the realtime options don't carry any risk of host-side timeouts because the index pulses occur at the normal rate.

index-suppression=no causes behavior like write-drain=eot, since when fake_fired is set during writing it also changes restart_pos. This commit disables that behavior for write-drain=realtime, but not for write-drain=instant which still carries timeout risk. Some users may be depending on the implicit behavior.