### PR TITLE
img: new geometry list for Otrona Attaché

### DIFF
--- a/examples/FF.CFG
+++ b/examples/FF.CFG
@@ -32,6 +32,7 @@ interface = jc
 # memotech: Memotech
 # msx: MSX
 # nascom: Nascom
+# otrona: Otrona Attaché
 # pc98: NEC PC-98
 # pc-dos: PC DOS Format (geometry determined from Bios Parameter Block)
 # tandy-coco: Tandy Color Computer (CoCo)

--- a/inc/config.h
+++ b/inc/config.h
@@ -89,6 +89,7 @@ struct packed ff_cfg {
 #define HOST_nascom     15
 #define HOST_casio      16
 #define HOST_ibm_3174   17
+#define HOST_otrona     18
     uint8_t host;
     /* Bitfields within display_type field. */
 #define DISPLAY_auto     0

--- a/src/image/img.c
+++ b/src/image/img.c
@@ -172,6 +172,9 @@ const static struct raw_type {
 }, uknc_type[] = {
     { 10, _S(2), 0, 38, 1, 2, 1, 0, 0, 0, _C(80), _R(300) },
     { 0 }
+}, otrona_type[] = {
+    { 10, _S(2), _IAM, 20, 5, 2, 1, 0, 0, 0, _C(40), _R(300) },
+    { 0 }
 };
 
 static FSIZE_t im_size(struct image *im)
@@ -584,6 +587,9 @@ static bool_t img_open(struct image *im)
         return ti99_open(im);
     case HOST_uknc:
         return uknc_open(im);
+    case HOST_otrona:
+        type = otrona_type;
+        break;
     default:
         type = img_type;
         break;

--- a/src/main.c
+++ b/src/main.c
@@ -1004,6 +1004,7 @@ static void read_ff_cfg(void)
                 : !strcmp(opts.arg, "tandy-coco") ? HOST_tandy_coco
                 : !strcmp(opts.arg, "ti99") ? HOST_ti99
                 : !strcmp(opts.arg, "uknc") ? HOST_uknc
+                : !strcmp(opts.arg, "otrona") ? HOST_otrona
                 : HOST_unspecified;
             break;
 


### PR DESCRIPTION
This adds support for Otrona Attaché host computers. A sample image is available on bitsavers:
http://www.bitsavers.org/bits/Otrona/Attache/Attache_Boot_2.2.5.IMD

The Attaché had an optional 98 TPI drive, but I don't have any way of testing it so I only implemented the default 48 TPI setup.

Specs:
* NEC µPD765 controller
* Remex RFD480 drive
* 40 tracks
* 2 heads
* 10 sectors per track
* 512 byte sectors
* No skew

Note: The Otrona requires a RDY signal on pin 6, which is not connected on the Gotek. A bodge is needed between pin 2 and 6, and pin 2 needs to be configured as RDY.