### PR TITLE
Add support for AT32F435 on KC30 rev 1

### DIFF
--- a/src/gotek/board.c
+++ b/src/gotek/board.c
@@ -262,6 +262,18 @@ void board_init(void)
                     has_kc30_header = 1;
                 }
                 gpio_configure_pin(gpiof, 7, GPI_floating);
+#else
+                rcc->ahb1enr |= RCC_AHB1ENR_GPIOHEN;
+                gpio_configure_pin(gpioh, 2, GPI_pull_up);
+                delay_us(100);
+                if (gpio_read_pin(gpioh, 2) == HIGH) {
+                    /* KC30 Rev 1. has "select" on PH2. Old boards
+                       have this pin pulled low. As long as the user
+                       doesn't press select during power-up, this allows
+                       to recognize the board. */
+                    has_kc30_header = 1;
+                }
+                gpio_configure_pin(gpioh, 2, GPI_floating);
 #endif
             }
 


### PR DESCRIPTION
I replaced the AT32F415 by an AT32F435 on my SFRKC30AT3 Gotek, and lost the rotary encoder functionaliy after flashing the firmware. It turns out that there is no detection of the KC30 boards in the AT32F435 firmware, because "PF7 doesn't exist". Yet PF6 does exist, and that pin seems to be able to be used for KC30 detection as well (as long as the user doesn't press select on power-up). This patch implements KC30 Rev.1 detection in the F435 firmware.