### PR TITLE
Example IMG.CFG for a Radstone PME 68-12 VME based Motorola 68000 system with a WD1772 controller

### DIFF
--- a/examples/Host/PSOS/IMG.CFG
+++ b/examples/Host/PSOS/IMG.CFG
@@ -1,0 +1,26 @@
+# These settings are for use with the Flashfloppy Emulator in the FF/IMG.CFG file.
+# https://github.com/keirf/flashfloppy
+
+# Specifically for use with images taken using Fluxengine's PSOS profile.
+# https://cowlark.com/fluxengine
+
+# These settings might be useful for anyone attempting to work with:
+# A Motorola 68000 VME based system, specifically:
+#  * Containing a WD1772 controller
+#  * running the PSOS RTOS from Software Components Group (SCG)
+
+# For this to work you will also need "interface=shugart" in FF/FF.CFG
+
+# Enjoy!
+
+# Here we tell FlashFloppy that any images which are 819200 bytes long (which is reasonably unique to this format) and apply specific settings required to emulate these floppies.
+[::819200]
+cyls = 80
+heads = 2
+# 5 sectors per track is less than the usual. This is because this system uses larger than typical sectors.
+secs = 5
+# .img floppy images typically interleave data from the two side of the floppy (which is contrast to how data is logically stored on both IBM PC systems, as well as this particular system). interleaved is the default option for flashfloppy.
+# Uniquely, however, PSOS images do require swapped-sides to function properly.
+file-layout=interleaved,sides-swapped
+# Rather uniquely, this system uses 1024-byte sectors, whereas 512-byte is much more common in floppy formats.
+bps = 1024

--- a/examples/Host/PSOS/IMG.CFG
+++ b/examples/Host/PSOS/IMG.CFG
@@ -5,7 +5,7 @@
 # https://cowlark.com/fluxengine
 
 # These settings might be useful for anyone attempting to work with:
-# A Motorola 68000 VME based system, specifically:
+# A Radstone PME 68-12 VME based Motorola 68000 system, specifically:
 #  * Containing a WD1772 controller
 #  * running the PSOS RTOS from Software Components Group (SCG)
 


### PR DESCRIPTION
This is a rather unusual system which took a bit of effort to figure out settings for. Enjoy!